### PR TITLE
Settings: fix backlight illumination wrong summary

### DIFF
--- a/src/com/android/settings/cyanogenmod/BacklightTimeoutSeekBar.java
+++ b/src/com/android/settings/cyanogenmod/BacklightTimeoutSeekBar.java
@@ -60,27 +60,6 @@ public class BacklightTimeoutSeekBar extends SeekBar {
     }
 
     @Override
-    public void setProgress(int progress) {
-        if (progress == 0) {
-            progress = getMax();
-        } else {
-            progress--;
-        }
-        super.setProgress(progress);
-    }
-
-    @Override
-    public int getProgress() {
-        int progress = super.getProgress();
-        if (mUpdatingThumb) {
-            return progress;
-        } else if (progress == getMax()) {
-            return 0;
-        }
-        return progress + 1;
-    }
-
-    @Override
     protected int updateTouchProgress(int lastProgress, int newProgress) {
         if (newProgress < mMax) {
             return newProgress;

--- a/src/com/android/settings/cyanogenmod/ButtonBacklightBrightness.java
+++ b/src/com/android/settings/cyanogenmod/ButtonBacklightBrightness.java
@@ -252,7 +252,7 @@ public class ButtonBacklightBrightness extends DialogPreference implements
             if (buttonBrightness == 0) {
                 setSummary(R.string.backlight_summary_disabled);
             } else if (timeout == 0) {
-                setSummary(R.string.backlight_summary_enabled);
+                setSummary(R.string.backlight_timeout_unlimited);
             } else {
                 setSummary(getContext().getString(R.string.backlight_summary_enabled_with_timeout,
                         getTimeoutString(timeout)));


### PR DESCRIPTION
This fixes the visual indicator of the button illumination summary after
trying to disable. Previously after setting the timeout to never, would
display a summary of "1", or with 5, it would end up displaying 6 after
applying the settings.

Ticket: CYNGNOS-2565

Change-Id: Ia982e4849d0099b6e208b362770a431dc89dd2f1
Signed-off-by: Roman Birg <roman@cyngn.com>